### PR TITLE
docs(feature/add-bash-script): Update library link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This project is licensed under the Apache License. See the [LICENSE](https://git
 - **Inspiration:** Special thanks to all open-source contributors and communities that inspire and support developers around the world.
 - **Libraries and Tools:** This project uses several libraries and tools that enhance its functionality, including:
   - [pywhatkit](https://github.com/Ankit404butfound/pywhatkit) for sending WhatsApp messages.
-  - [libnotify](https://developer.gnome.org/libnotify/stable/) for desktop notifications.
+  - [libnotify](https://gitlab.gnome.org/GNOME/libnotify) for desktop notifications.
 - **Community:** Thanks to the programming and developer community for their invaluable resources, tutorials, and documentation that helped make this project possible.
 
 ## Contact Information


### PR DESCRIPTION
This commit updates the link for the `libnotify` library in the README.md file to point to the correct GitLab repository. This change ensures that users can access the most accurate and up-to-date documentation for the library used for desktop notifications in this project.

- Updated the `libnotify` link from GNOME documentation to the correct GitLab repository.